### PR TITLE
transmission_upload: Fix downloadDir check

### DIFF
--- a/examples/transmission_upload.py
+++ b/examples/transmission_upload.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     for t in torrents:
         f = t._fields
 
-        if f['downloadDir'].value not in args.directory:
+        if not os.path.samefile(f['downloadDir'].value, args.directory):
             continue
         if t.status not in ['seeding', 'stopped']:
             continue


### PR DESCRIPTION
The previous downloadDir check was very fragile and would fail if the
downloadDir on the torrent had a "/" and the downloadDir argument did
not. Instead, we can use `os.path.samefile` which doesn't care about
this.